### PR TITLE
Fixed bug: SSLPort mandatory DSC property not optional

### DIFF
--- a/cADFS.psm1
+++ b/cADFS.psm1
@@ -125,7 +125,7 @@ class cADFSFarm {
     <#
     The SSLPort property specifies a non-standard SSL Port. For example: 8443.
     #>
-    [DscProperty(key)]
+    [DscProperty()]
     [string] $SSLPort;
 
     <#


### PR DESCRIPTION
Fixed bug where SSLPort was a mandatory DSC property when it shouldn't have been as it breaks for server pre-2016