### PR TITLE
cADFSSamlEndpoint: fix index definition and link to parent RPT

### DIFF
--- a/cADFS.psm1
+++ b/cADFS.psm1
@@ -576,7 +576,7 @@ class cADFSSamlEndpoint {
     [DscProperty(Mandatory)]
     [SAMLBinding] $Binding;
 
-    ### Index of the Endpoint
+    ### Index of the Endpoint, relative to the Protocol
     [DscProperty(Key)]
     [Int] $Index;
 
@@ -588,7 +588,7 @@ class cADFSSamlEndpoint {
     [DscProperty(Mandatory)]
     [String] $Location;
 
-    ### SAML Protocol that this endpoint implements
+    ### SAML Protocol that this endpoint implements (SAMLAssertionConsumer, SAMLLogout etc.)
     [DscProperty(Key)]
     [SAMLProtocol] $Protocol;
 
@@ -598,9 +598,9 @@ class cADFSSamlEndpoint {
         $AllCurrentSAMLEndpoints = (Get-AdfsRelyingPartyTrust -Name $this.Name).SamlEndpoints;
         Write-Verbose -Message 'Finished retrieving list of all current SAML Endpoints for the ADFS Relying Party Trust';
 
-        Write-Verbose -Message 'Starting retrieving SAML Endpoint at Index $this.Index';
-        $CurrentSAMLEndpoint = $AllCurrentSAMLEndpoints | Where-Object { $_.Index -eq $this.Index };
-        Write-Verbose -Message 'Finished retrieving SAML Endpoint at Index $this.Index';
+        Write-Verbose -Message "Starting retrieving SAML Endpoint at $($this.Protocol) / $($this.Index)";
+        $CurrentSAMLEndpoint = $AllCurrentSAMLEndpoints | Where-Object { $_.Protocol -eq $this.Protocol -and $_.Index -eq $this.Index };
+        Write-Verbose -Message "Finished retrieving SAML Endpoint";
 
         $this.Binding = $CurrentSAMLEndpoint.Binding;
         $this.Index = $CurrentSAMLEndpoint.Index;
@@ -617,7 +617,7 @@ class cADFSSamlEndpoint {
         Write-Verbose -Message 'Starting evaluating SAML Endpoint against desired state.';
 
         $AllCurrentSAMLEndpoints = (Get-AdfsRelyingPartyTrust -Name $this.Name).SamlEndpoints;
-        $CurrentSAMLEndpoint = $AllCurrentSAMLEndpoints | Where-Object { $_.Index -eq $this.Index };
+        $CurrentSAMLEndpoint = $AllCurrentSAMLEndpoints | Where-Object { $_.Protocol -eq $this.Protocol -and $_.Index -eq $this.Index };
 
         ### Assume that the system is complian, unless one of the specific settings does not match.
         $Compliance = $true;
@@ -661,7 +661,7 @@ class cADFSSamlEndpoint {
         $AllNewSAMLEndpoints = @();
         $AllCurrentSAMLEndpoints = (Get-AdfsRelyingPartyTrust -Name $this.Name).SamlEndpoints;
         ForEach ($CurrentSAMLEndpoint in $AllCurrentSAMLEndpoints) {
-            If ($CurrentSAMLEndpoint.Index -eq $this.Index) {
+            If ($CurrentSAMLEndpoint.Protocol -eq $this.Protocol -and $CurrentSAMLEndpoint.Index -eq $this.Index) {
                 $AllNewSAMLEndpoints += $ReplacementSAMLEndpoint;
             } Else {
                 $AllNewSAMLEndpoints += $CurrentSAMLEndpoint;

--- a/cADFS.psm1
+++ b/cADFS.psm1
@@ -568,8 +568,8 @@ class cADFSSamlEndpoint {
     [DscProperty()]
     [Ensure] $Ensure;
 
-    ### The Name property must be unique to each ADFS Relying Party application in a farm.
-    [DscProperty(Key)]
+    ### References the ADFS Relying Party in which to install this SAMLEndpoint
+    [DscProperty(Mandatory)]
     [string] $Name;
 
     ### Binding type (POST, Redirect, Artifact)


### PR DESCRIPTION
This fixes a few bugs in cADFSSamlEndpoint:

- `$Name` was marked as part of the key, which it isn't: it's a reference to another object.
- The uniqueness algorithms only considered `$Index`, while it is actually a composite Key with `$Protocol`.
- Finally, rewrites the logic that adds or replaces the modified SamlEndpoint in the parent RelyingPartyTrust object (see #8).

The fixes depend on each other, so although there are three separate commits, this belongs to a single PR.