### PR TITLE
fix rushed copy/paste from CertificateDsc

### DIFF
--- a/cADFS.psm1
+++ b/cADFS.psm1
@@ -1040,6 +1040,7 @@ class cADFSDeviceRegistration {
     }
 }
 
+# Find-Certificate is copied from https://github.com/PowerShell/CertificateDsc (MIT)
 <#
     .SYNOPSIS
     Locates one or more certificates using the passed certificate selector parameters.
@@ -1121,10 +1122,7 @@ function Find-Certificate {
     $certPath = Join-Path -Path 'Cert:\LocalMachine' -ChildPath $Store
 
     if (-not (Test-Path -Path $certPath)) {
-        # The Certificte Path is not valid
-        New-InvalidArgumentError `
-            -ErrorId 'CannotFindCertificatePath' `
-            -ErrorMessage ($LocalizedData.CertificatePathError -f $certPath)
+        throw [System.ArgumentException]::New("Certificate Path '$certPath' is not valid");
     } # if
 
     # Assemble the filter to use to select the certificate
@@ -1164,8 +1162,8 @@ function Find-Certificate {
     # Join all the filters together
     $certFilterScript = '(' + ($certFilters -join ' -and ') + ')'
 
-    Write-Verbose -Message ($LocalizedData.SearchingForCertificateUsingFilters `
-            -f $store, $certFilterScript)
+    Write-Verbose -Message ("Looking for certificate in Path {0} using filter '{1}'" `
+            -f $certPath, $certFilterScript)
 
     $certs = Get-ChildItem -Path $certPath |
         Where-Object -FilterScript ([ScriptBlock]::Create($certFilterScript))


### PR DESCRIPTION
The missing supporting code/data from CertificateDsc caused this part of the code not to emit verbose messages nor exceptions.