### PR TITLE
fix RPT creation when some parameters are null

### DIFF
--- a/cADFS.psm1
+++ b/cADFS.psm1
@@ -523,6 +523,16 @@ class cADFSRelyingPartyTrust {
         if (!$CurrentRelyingPartyTrust) {
             ### This code executes if the Relying Party Trust does not exist.
             Write-Verbose -Message ('The ADFS Relying Party Trust ({0}) does not exist. Creating it.' -f $this.Name);
+
+            # Add-AdfsRPT errors out when these arguments are $null, but they
+            # are required when trying to unconfigure these parameters with
+            # Set-AdfsRPT
+            @( 'WsFedEndpoint', 'EncryptionCertificate' ) | Foreach-Object {
+                if ($null -eq $RelyingPartyTrust[$_]) {
+                    $RelyingPartyTrust.Remove($_);
+                }
+            }
+
             Add-AdfsRelyingPartyTrust @RelyingPartyTrust;
         }
         else {


### PR DESCRIPTION
Some AdfsRelyingPartyTrust parameters are required to be `$null` in Set-AdfsRPT to be removed from the resource, but cannot be provided as `$null` arguments to Add-AdfsRPT.

This caused errors like "Cannot validate argument on parameter 'WsFedEndpoint'. The argument is null. Provide a valid value for the argument, and then try running the command again."

This PR depends on #12.